### PR TITLE
Fix write's return value

### DIFF
--- a/arduboy-pokemon-thing/UIObjectBase.h
+++ b/arduboy-pokemon-thing/UIObjectBase.h
@@ -16,7 +16,7 @@ protected:
 	size_t write(uint8_t letter) override
 	{
 		messageBuffer->write(letter);
-		return 0;
+		return 1;
 	}
 public:
 	UIObjectBase(StandardMessageBuffer & messageBuffer)


### PR DESCRIPTION
'write' should return the number of chars written.
By returning 0 all the time, [it causes another overload of `write` to return early]((https://github.com/arduino/ArduinoCore-avr/blob/master/cores/arduino/Print.cpp#L38)),
which results in only the first character of a string being printed.